### PR TITLE
Add ammonite

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -20,6 +20,7 @@
   programs.home-manager.enable = true;
 
   home.packages = [
+    pkgs.ammonite
     pkgs.nixpkgs-fmt
     pkgs.ripgrep
     pkgs.tmux

--- a/scripts/test
+++ b/scripts/test
@@ -9,17 +9,28 @@ Run tests.
 "
 }
 
+function build_home() {
+    export NIX_PATH="${NIX_PATH:+$NIX_PATH:}:$HOME/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/root/channels"
+    nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
+    nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
+    nix-channel --update
+    nix-shell '<home-manager>' -A install
+    home-manager switch -f home.nix
+}
+
+function check_formatting() {
+    nixpkgs-fmt --check **/*.nix
+}
+
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
         echo "Building home derivation"
-        export NIX_PATH="${NIX_PATH:+$NIX_PATH:}:$HOME/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/root/channels"
-        nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
-        nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
-        nix-channel --update
-        nix-shell '<home-manager>' -A install
-        home-manager switch -f home.nix
+        build_home
+
+        echo "Verifying all nix files follow formatting conventions"
+        check_formatting
     fi
 fi
 

--- a/scripts/test
+++ b/scripts/test
@@ -19,7 +19,7 @@ function build_home() {
 }
 
 function check_formatting() {
-    nixpkgs-fmt --check **/*.nix
+    nixpkgs-fmt --check *.nix
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then


### PR DESCRIPTION
This PR adds ammonite to home manager. It _also_ adds a formatting check to CI after the home manager build (since the home manager build makes `nixpkgs-fmt` available) to make sure that any nix files I add in the future have a consistent format.