### PR TITLE
Use $USER instead of root hardcode

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -10,7 +10,7 @@ Run tests.
 }
 
 function build_home() {
-    export NIX_PATH="${NIX_PATH:+$NIX_PATH:}:$HOME/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/root/channels"
+    export NIX_PATH="${NIX_PATH:+$NIX_PATH:}:$HOME/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/$USER/channels"
     nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
     nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
     nix-channel --update


### PR DESCRIPTION
This PR changes the path in `scripts/test` from hardcoded `root` user channels to channels matching the current value of `$USER`. It avoids a name collision in package names after running the tests locally.