### PR TITLE
Patch to disable failing hm dependency

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -47,6 +47,7 @@ in
   home.stateVersion = "22.05";
 
   programs = {
+
     # Let Home Manager install and manage itself.
     home-manager.enable = true;
 
@@ -54,6 +55,10 @@ in
     tmux.enable = true;
     tmux.extraConfig = builtins.readFile ./dotfiles/tmux.conf;
   };
+
+  # https://github.com/NixOS/nixpkgs/issues/196651
+  manual.manpages.enable = false;
+
 
   home.packages = shellUtilities ++ systemUtilities ++ scalaDeps ++ ourobouros;
 }


### PR DESCRIPTION
As of about 24 hours ago, home manager can't be built without disabling the `manual` package -- https://github.com/nix-community/home-manager/issues/3342

This PR does that off of `main` so I can build things again.