### PR TITLE
Switch to lazygit

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -35,6 +35,15 @@ let
     (pkgs.nerdfonts.override { fonts = [ "Hasklig" "SourceCodePro" ]; })
   ];
 
+  lazyGitNeovimConfig =
+    let
+      extraConfigLines = builtins.readFile ./neovim/extra.lua;
+      configFileLocation =
+        if builtins.currentSystem == "x86_64-darwin"
+        then "Library/Application Support/lazygit/config.yml"
+        else ".config/lazygit/config.yml";
+    in
+    builtins.replaceStrings [ "SUBSTITUTE" ] [ "${builtins.getEnv "HOME"}/${configFileLocation}" ] extraConfigLines;
 in
 {
   # Home Manager needs a bit of information about you and the
@@ -52,22 +61,24 @@ in
   # changes in each release.
   home.stateVersion = "22.11";
 
-
   xdg.configFile.nvim = {
     source = ./neovim;
     recursive = true;
   };
 
+  xdg.configFile."nvim/lua/lazygit-config-extra.lua".text = lazyGitNeovimConfig;
 
   programs = {
 
     # Let Home Manager install and manage itself.
     home-manager.enable = true;
 
-    # Enable and configure tmux
-    tmux = {
+    lazygit = {
       enable = true;
-      extraConfig = builtins.readFile ./dotfiles/tmux.conf;
+      settings.gui = {
+        theme.lightTheme = true;
+        showIcons = true;
+      };
     };
 
     neovim = {
@@ -80,6 +91,7 @@ in
         [
           cmp-nvim-lsp
           fzf-lua
+          lazygit-nvim
           luasnip
           markdown-preview-nvim
           neogit
@@ -101,7 +113,15 @@ in
         rnix-lsp
         nodePackages.typescript-language-server
       ];
+
     };
+
+    # Enable and configure tmux
+    tmux = {
+      enable = true;
+      extraConfig = builtins.readFile ./dotfiles/tmux.conf;
+    };
+
   };
 
   fonts.fontconfig.enable = true;

--- a/neovim/extra.lua
+++ b/neovim/extra.lua
@@ -1,0 +1,2 @@
+vim.g.lazygit_use_custom_config_file_path = 1;
+vim.g.lazygit_config_file_path = "SUBSTITUTE"

--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -12,6 +12,7 @@ vim.api.nvim_set_keymap("n", "<leader>mp", "<cmd>MarkdownPreview<CR>", { noremap
 require("completion-config")
 require("custom-lsp-config")
 require("fzf-config")
-require("neogit-config")
+require("lazygit-config")
+require("lazygit-config-extra")
 require("tree-config")
 require("vim-stuff")

--- a/neovim/lua/lazygit-config.lua
+++ b/neovim/lua/lazygit-config.lua
@@ -1,0 +1,3 @@
+-- launch git status buffer conveniently
+vim.api.nvim_set_keymap("n", "<space>gg", "<cmd>:LazyGit<CR>", { noremap = true })
+vim.api.nvim_set_keymap("n", "<space>gf", "<cmd>:LazyGitCurrentFile<CR>", { noremap = true })

--- a/neovim/lua/neogit-config.lua
+++ b/neovim/lua/neogit-config.lua
@@ -1,8 +1,0 @@
--- setup neogit
-local neogit = require("neogit")
-neogit.setup {
-  kind = "vsplit"
-}
-
--- launch git conveniently
-vim.api.nvim_set_keymap("n", "<space>gs", "<cmd>:Neogit<CR>", { noremap = true })


### PR DESCRIPTION
This PR switches over to `lazygit`. I also tried out `fugitive`, but the status window was behaving strangely in some repos (just reopening the current buffer instead of showing status) and it's fully vimscript instead of lua, so I opted against. `lazygit` pops up a floating window that responds to `q`, is independently maintained (so if I bail on neovim it'll still be nice to know), plays nicely with the light color scheme (as of like a week ago! what a great sign for maintenance), and shows a bunch of nice contextual information about git status.

The cost was I had to do a little extra work to get neovim to know about the config file location (which is important for getting the colors to cooperate) but I think it was worth it.