### PR TITLE
Unify home derivation activation

### DIFF
--- a/scripts/switch
+++ b/scripts/switch
@@ -1,25 +1,36 @@
 #!/bin/bash
 
-set -e
+set -eu
+
+function usage() {
+  echo -n \
+"Usage: $(basename "$0") macos|linux
+Build and switch to a new home manager generation
+"
+}
 
 function build_linux() {
   nix build --impure .#homeConfigurations.linux.activationPackage
-
-  ./result/activate
 }
 
 function build_macos() {
-  export NIX_PATH="${NIX_PATH:+$NIX_PATH:}:$HOME/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/$USER/channels"
-  nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
-  nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
-  nix-channel --update
-  # install home-manager
-  nix-shell '<home-manager>' -A install
-  # switch to the current home manager derivation
-  home-manager switch -f home.nix
+  nix build --impure .#homeConfigurations.macOS.activationPackage
 }
 
-case "${1}" in
-  linux) build_linux;;
-  macos) build_macos;;
-esac
+function activate_home() {
+  nix develop nixpkgs#bash --command ./result/activate
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  if [ "${1:-}" = "--help" ]; then
+    usage
+  else
+    case "${1}" in
+      linux) build_linux;;
+      macos) build_macos;;
+    esac
+
+    activate_home
+  fi
+fi
+

--- a/scripts/test
+++ b/scripts/test
@@ -3,31 +3,32 @@
 set -eu
 
 function usage() {
-    echo -n \
+  echo -n \
 "Usage: $(basename "$0")
 Run tests.
 "
 }
 
 function build_home() {
-    ./scripts/switch "${1}"
+  ./scripts/switch "${1}"
 }
 
 function check_formatting() {
-    nixpkgs-fmt --check *.nix
+  nixpkgs-fmt --check *.nix
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-    if [ "${1:-}" = "--help" ]; then
-        usage
-    else
-        echo "Building home derivation"
-        lowercasedArg=$(tr '[:upper:]' '[:lower:]' <<< "${1}")
-        build_home "${lowercasedArg}"
+  if [ "${1:-}" = "--help" ]; then
+    usage
+  else
+    echo "Building home derivation"
+    lowercasedArg=$(tr '[:upper:]' '[:lower:]' <<< "${1}")
+    build_home "${lowercasedArg}"
 
-        echo "Verifying all nix files follow formatting conventions"
-        check_formatting
-    fi
+    echo "Verifying all nix files follow formatting conventions"
+    # This is after building home, which takes longer, because it depends
+    # on a formatting checker installed in the home manager derivation
+    check_formatting
+  fi
 fi
-
 


### PR DESCRIPTION
MacOS couldn't activate the home derivation because event Ventura has bash 3.x my god why does anyone use these things

ANYWAY, running activation in a dev shell does the trick.

I also took the opportunity to add usage to `switch` and explained why formatting is after the expensive operation