### PR TITLE
Use vertical org mode split

### DIFF
--- a/dotfiles/neovim/lua/custom-orgmode.lua
+++ b/dotfiles/neovim/lua/custom-orgmode.lua
@@ -1,6 +1,8 @@
 require("orgmode").setup({
   org_agenda_files = {"~/.org/agenda/*"},
   org_default_notes_file = "~/.org/refile.org",
+
+  win_split_mode = "vertical"
 })
 
 -- it's not clear to me whether this is actually doing anything.


### PR DESCRIPTION
Vertical split seems less sensitive to weird sizing issues encountered with the horizontal split, where when the horizontal split was the only window, the whole window was resized down to 20 lines for some reason.