### PR TITLE
Enable python lsp support in nvim

### DIFF
--- a/dotfiles/neovim/lua/custom-lsp-config.lua
+++ b/dotfiles/neovim/lua/custom-lsp-config.lua
@@ -54,6 +54,18 @@ require("lspconfig").dhall_lsp_server.setup{}
 -- activate kotlin ls
 require("lspconfig").kotlin_language_server.setup({})
 
+-- activate python-language-server
+require("lspconfig").pylsp.setup({
+  pylsp = {
+    plugins = {
+      flake8 = {
+        enabled = true;
+      }
+    }
+  }
+})
+
+
 -- configure lsp keybindings
 vim.api.nvim_set_keymap(
   "n", -- mode

--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1671966569,
-        "narHash": "sha256-jbLgfSnmLchARBNFRvCic63CFQ9LAyvlXnBpc2kwjQc=",
+        "lastModified": 1676367705,
+        "narHash": "sha256-un5UbRat9TwruyImtwUGcKF823rCEp4fQxnsaLFL7CM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c55fa26ce05fee8e063db22918d05a73d430b2ea",
+        "rev": "da72e6fc6b7dc0c3f94edbd310aae7cd95c678b5",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671200928,
-        "narHash": "sha256-mZfzDyzojwj6I0wyooIjGIn81WtGVnx6+avU5Wv+VKU=",
+        "lastModified": 1675115703,
+        "narHash": "sha256-4zetAPSyY0D77x+Ww9QBe8RHn1akvIvHJ/kgg8kGDbk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "757b82211463dd5ba1475b6851d3731dfe14d377",
+        "rev": "2caf4ef5005ecc68141ecb4aac271079f7371c44",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1671883564,
-        "narHash": "sha256-C15oAtyupmLB3coZY7qzEHXjhtUx/+77olVdqVMruAg=",
+        "lastModified": 1676375384,
+        "narHash": "sha256-6HI3jZiuJX+KLz05cocYy2mBAWlISEKHU84ftYfxHZ8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dac57a4eccf1442e8bf4030df6fcbb55883cb682",
+        "rev": "c43f676c938662072772339be6269226c77b51b8",
         "type": "github"
       },
       "original": {

--- a/home.nix
+++ b/home.nix
@@ -125,6 +125,12 @@ in
         fzf
         kotlin-language-server
         nodePackages.typescript-language-server
+        (python311.withPackages (ps: [
+          ps.flake8
+          ps.python-lsp-server
+          ps.pylsp-mypy
+          ps.python-lsp-black
+        ]))
         rnix-lsp
       ];
 

--- a/home.nix
+++ b/home.nix
@@ -125,7 +125,7 @@ in
         fzf
         kotlin-language-server
         nodePackages.typescript-language-server
-        (python311.withPackages (ps: [
+        (python3.withPackages (ps: [
           ps.flake8
           ps.python-lsp-server
           ps.pylsp-mypy


### PR DESCRIPTION
At this point this has been [used in anger](https://github.com/jisantuc/ifsc-client), so it's good to add to the home.