### PR TITLE
Limit tmux history and disable mouse

### DIFF
--- a/dotfiles/tmux.conf
+++ b/dotfiles/tmux.conf
@@ -1,7 +1,7 @@
 # For tmux v2.6
 
-# Make mouse useful in copy mode
-set -g mouse on
+# Disable mouse interactions
+set -g mouse off
 
 # vi mode for navigation
 setw -g mode-keys vi
@@ -13,9 +13,6 @@ bind-key -T copy-mode-vi r send-keys -X rectangle-toggle
 
 # Linux, requires xclip
 bind -T copy-mode-vi y send -X copy-pipe-and-cancel "xclip -selection c"
-
-# source .tmux.conf as suggested in `man tmux`
-bind R source-file '~/.tmux.conf'
 
 # emacs key bindings in tmux command prompt (prefix + :) are better than
 # vi keys, even for vim users
@@ -46,7 +43,7 @@ set -g status-left ''
 set -g status-right ''
 
 # increase scrollback lines
-set -g history-limit 500000
+set -g history-limit 10000
 
 # avoid delaying escape key in vim
 set -sg escape-time 10


### PR DESCRIPTION
Swap memory impact on MacOS is _painful_, so get rid of the super long history. Also turn the mouse off so I don't accidentally click things, which I do _all the time_