### PR TITLE
Add git-crypt

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -19,6 +19,9 @@ let
     # record terminal activity
     # https://asciinema.org/
     pkgs.asciinema
+    # transparent (to end-user) encrypt/decrypt of secrets in a git repository
+    # https://github.com/AGWA/git-crypt
+    pkgs.git-crypt
     # nicer view of system resource utilization
     # https://htop.dev/
     pkgs.htop


### PR DESCRIPTION
This PR adds `git-crypt`, which I'm using on a new work computer and for secrets management on `narcissus`: https://github.com/jisantuc/narcissus/tree/feature/js/add-tf-serverless-setup (link will die once that branch merges, which will be... someday).

As an example usage, consider a nix expression full of secrets called `secrets.nix` like:

```
{
  secretToken = "abc123";
}
```

In order to use that value in a flake, `secrets.nix` has to be in version control. However, secrets should _never_ be in version control. `git-crypt` to the rescue! With a `.gitattributes` file like

```
secrets.nix filter=git-crypt diff=git-crypt
```

`secrets.nix` will be encrypted when committing, but will look like plaintext to the end user (me) when interacting with it via `git diff` or looking at commits including it.