### PR TITLE
Add conceal toggle bindings

### DIFF
--- a/dotfiles/neovim/ftplugin/org.lua
+++ b/dotfiles/neovim/ftplugin/org.lua
@@ -1,0 +1,13 @@
+-- toggle conceal level between 0 and 2
+-- 0 conceals nothing, 2 makes links concealed
+
+function conceal()
+        vim.opt.conceallevel = 2
+end
+
+function noconceal()
+        vim.opt.conceallevel = 0
+end
+
+vim.keymap.set("n", "<leader>osc", conceal, { desc = "conceal" })
+vim.keymap.set("n", "<leader>osC", noconceal, { desc = "no conceal" })


### PR DESCRIPTION
`<leader>osc` to conceal at level 2 (little `c` because conceal makes less displayed text), `<leader>osC` to conceal at level 0 (big `C` because level 0 shows all the text)