### PR TITLE
Set git root name as pane name

### DIFF
--- a/dotfiles/tmux.conf
+++ b/dotfiles/tmux.conf
@@ -40,7 +40,7 @@ set-window-option -g window-status-current-style fg="#C7CEDB"
 
 # remove administrative debris (session name, hostname, time) in status bar
 set -g status-left ''
-set -g status-right 'Continuum: #{continuum_status}'
+set -g status-right ''
 
 # increase scrollback lines
 set -g history-limit 10000

--- a/dotfiles/tmux.conf
+++ b/dotfiles/tmux.conf
@@ -40,7 +40,7 @@ set-window-option -g window-status-current-style fg="#C7CEDB"
 
 # remove administrative debris (session name, hostname, time) in status bar
 set -g status-left ''
-set -g status-right ''
+set -g status-right 'Continuum: #{continuum_status}'
 
 # increase scrollback lines
 set -g history-limit 10000
@@ -48,24 +48,13 @@ set -g history-limit 10000
 # avoid delaying escape key in vim
 set -sg escape-time 10
 
-# needed to support auto-reloading in vim within tmux session
-set -g focus-events on
-
-# Plugin manager
-set -g @plugin 'tmux-plugins/tpm'
-# Save tmux session between restarts automatically
-set -g @plugin 'tmux-plugins/tmux-resurrect'
-set -g @resurrect-strategy-vim 'session'
-set -g @plugin 'tmux-plugins/tmux-continuum'
-set -g @continuum-restore 'on'
-set -g @resurrect-capture-pane-contents 'on'
-set -g @continuum-save-interval '5'
-# Window/pane management
-set -g @plugin 'tmux-plugins/tmux-pain-control'
-
 # split windows better
 bind '|' split-pane -h -c "#{pane_current_path}"
 bind '"' split-pane -v -c "#{pane_current_path}"
 
 # run fish
 set -g default-command $HOME/.nix-profile/bin/fish
+
+# name panes for git root
+set -g automatic-rename on
+set -g automatic-rename-format '#(basename "$(git -C #{pane_current_path} rev-parse --show-toplevel 2>/dev/null || echo "#{pane_current_path}")")'


### PR DESCRIPTION
This PR sets the output of `git rev-parse --show-toplevel` as pane names.

TODO:

* [x] remove incidental change from messing around with continuum