### PR TITLE
Fix nix lsp config formatting and add lua

### DIFF
--- a/dotfiles/neovim/ftplugin/http.lua
+++ b/dotfiles/neovim/ftplugin/http.lua
@@ -5,4 +5,3 @@ vim.api.nvim_set_keymap("n", "<leader>hs", "<Plug>RestNvim<CR>", { noremap = tru
 vim.api.nvim_set_keymap("n", "<leader>hp", "<Plug>RestNvimPreview<CR>", { noremap = true })
 -- rerun last command
 vim.api.nvim_set_keymap("n", "<leader>hr", "<Plug>RestNvimLast<CR>", { noremap = true })
-

--- a/dotfiles/neovim/ftplugin/org.lua
+++ b/dotfiles/neovim/ftplugin/org.lua
@@ -1,11 +1,10 @@
 -- toggle conceal level between 0 and 2
 -- 0 conceals nothing, 2 makes links concealed
-
-function conceal()
+local function conceal()
         vim.opt.conceallevel = 2
 end
 
-function noconceal()
+local function noconceal()
         vim.opt.conceallevel = 0
 end
 

--- a/dotfiles/neovim/lua/completion-config.lua
+++ b/dotfiles/neovim/lua/completion-config.lua
@@ -1,25 +1,24 @@
 local cmp = require("cmp")
 
 cmp.setup({
-  -- add additional completion sources here
-  -- names for completion sources will often be documented in other
-  -- plugins' readmes
-  sources = cmp.config.sources({
-    { name = "nvim_lsp", max_item_count = 10 },
-    { name = "treesitter", max_item_count = 10 },
-    { name = "luasnip" },
-    { name = "orgmode" }
-  }, { name = "buffer" }),
-  mapping = cmp.mapping.preset.insert({
-      ['<C-e>'] = cmp.mapping.abort(),
-      ['<CR>'] = cmp.mapping.confirm({ select = true })
-  })
+        -- add additional completion sources here
+        -- names for completion sources will often be documented in other
+        -- plugins' readmes
+        sources = cmp.config.sources({
+                { name = "nvim_lsp",   max_item_count = 10 },
+                { name = "treesitter", max_item_count = 10 },
+                { name = "luasnip" },
+                { name = "orgmode" }
+        }, { name = "buffer" }),
+        mapping = cmp.mapping.preset.insert({
+                ['<C-e>'] = cmp.mapping.abort(),
+                ['<CR>'] = cmp.mapping.confirm({ select = true })
+        })
 })
 
 cmp.setup.cmdline({ '/', '?' }, {
-  mapping = cmp.mapping.preset.cmdline(),
-  sources = {
-    { name = 'buffer' }
-  }
+        mapping = cmp.mapping.preset.cmdline(),
+        sources = {
+                { name = 'buffer' }
+        }
 })
-

--- a/dotfiles/neovim/lua/custom-jq-config.lua
+++ b/dotfiles/neovim/lua/custom-jq-config.lua
@@ -1,11 +1,11 @@
-jqConfig = require('nvim-jqx.config')
+local jqConfig = require('nvim-jqx.config')
 
 jqConfig.close_window_key = 'q'
 
 -- add bindings for querying and listing keys
 vim.api.nvim_set_keymap(
-  "n", "<leader>jq", "<cmd>JqxQuery<CR>", { noremap = true }
+        "n", "<leader>jq", "<cmd>JqxQuery<CR>", { noremap = true }
 )
 vim.api.nvim_set_keymap(
-  "n", "<leader>jl", "<cmd>JqxList<CR>", { noremap = true }
+        "n", "<leader>jl", "<cmd>JqxList<CR>", { noremap = true }
 )

--- a/dotfiles/neovim/lua/custom-lsp-config.lua
+++ b/dotfiles/neovim/lua/custom-lsp-config.lua
@@ -1,67 +1,110 @@
 -- activate and configure metals
 local nvim_metals_group = vim.api.nvim_create_augroup("nvim-metals", { clear = true })
 vim.api.nvim_create_autocmd("FileType", {
-  pattern = { "scala", "sbt", ".worksheet.sc" },
-  callback = function()
-    require("metals").initialize_or_attach({})
-  end,
-  group = nvim_metals_group,
+        pattern = { "scala", "sbt", ".worksheet.sc" },
+        callback = function()
+                require("metals").initialize_or_attach({})
+        end,
+        group = nvim_metals_group,
 })
 
-metals_config = require("metals").bare_config()
+local metals_config = require("metals").bare_config()
 metals_config.settings = {
-       showImplicitArguments = true,
-       excludedPackages = {
-        "akka.actor.typed.javadsl",
-        "com.github.swagger.akka.javadsl"
-       }
+        showImplicitArguments = true,
+        excludedPackages = {
+                "akka.actor.typed.javadsl",
+                "com.github.swagger.akka.javadsl"
+        }
 }
 metals_config.init_options.statusBarProvider = "on"
 
 metals_config.capabilities = require("cmp_nvim_lsp").default_capabilities()
 
--- activate rnix-lsp
-require'lspconfig'.nil_ls.setup{}
+-- activate nil_ls
+require("lspconfig").nil_ls.setup {
+        settings = {
+                ['nil'] = {
+                        formatting = {
+                                command = { "nixpkgs-fmt" },
+                        },
+                },
+        }
+}
+
+-- set up lua language server specifically for nvim files
+-- see docs:
+-- https://github.com/neovim/nvim-lspconfig/blob/2b361e043810d5587d9af0787f8ce40da92ec5e9/doc/server_configurations.md#lua_ls
+require("lspconfig").lua_ls.setup {
+        on_init = function(client)
+                local path = client.workspace_folders[1].name
+                if not vim.loop.fs_stat(path .. '/.luarc.json') and not vim.loop.fs_stat(path .. '/.luarc.jsonc') then
+                        client.config.settings = vim.tbl_deep_extend('force', client.config.settings, {
+                                Lua = {
+                                        runtime = {
+                                                -- Tell the language server which version of Lua you're using
+                                                -- (most likely LuaJIT in the case of Neovim)
+                                                version = 'LuaJIT'
+                                        },
+                                        -- Make the server aware of Neovim runtime files
+                                        workspace = {
+                                                checkThirdParty = false,
+                                                library = {
+                                                        vim.env.VIMRUNTIME
+                                                        -- "${3rd}/luv/library"
+                                                        -- "${3rd}/busted/library",
+                                                }
+                                                -- or pull in all of 'runtimepath'. NOTE: this is a lot slower
+                                                -- library = vim.api.nvim_get_runtime_file("", true)
+                                        }
+                                }
+                        })
+
+                        client.notify("workspace/didChangeConfiguration", { settings = client.config.settings })
+                end
+                return true
+        end
+
+}
 
 -- activate purescript ls
-require("lspconfig").purescriptls.setup{}
+require("lspconfig").purescriptls.setup {}
 
 -- activate typescript ls
-require("lspconfig").tsserver.setup{}
+require("lspconfig").tsserver.setup {}
 
 -- activate hls
 local ht = require('haskell-tools')
 ht.setup {
-  tools = {
-    hover = {
-      disable = true,
-    }
-  },
-  hls = {
-    -- See nvim-lspconfig's  suggested configuration for keymaps, etc.
-    settings = {
-      haskell = {
-        formattingProvider = 'ormolu',
-      }
-    }
-  },
+        tools = {
+                hover = {
+                        disable = true,
+                }
+        },
+        hls = {
+                -- See nvim-lspconfig's  suggested configuration for keymaps, etc.
+                settings = {
+                        haskell = {
+                                formattingProvider = 'ormolu',
+                        }
+                }
+        },
 }
 
 -- activate dhall ls
-require("lspconfig").dhall_lsp_server.setup{}
+require("lspconfig").dhall_lsp_server.setup {}
 
 -- activate kotlin ls
 require("lspconfig").kotlin_language_server.setup({})
 
 -- activate pyright
-require("lspconfig").pyright.setup{}
+require("lspconfig").pyright.setup {}
 
 -- configure lsp keybindings
 vim.api.nvim_set_keymap(
-  "n", -- mode
-  "gd", -- key chord
-  "<cmd>lua vim.lsp.buf.definition()<CR>", -- command to execute
-  { noremap = true } -- some options, I don"t know what I can do here
+        "n",                                     -- mode
+        "gd",                                    -- key chord
+        "<cmd>lua vim.lsp.buf.definition()<CR>", -- command to execute
+        { noremap = true }                       -- some options, I don"t know what I can do here
 )
 
 vim.api.nvim_set_keymap("n", "K", "<cmd>lua vim.lsp.buf.hover()<CR>", { noremap = true })
@@ -74,6 +117,8 @@ vim.api.nvim_set_keymap("n", "<leader>cf", "<cmd>lua vim.lsp.buf.format { async 
 vim.api.nvim_set_keymap("n", "<leader>ca", "<cmd>lua vim.lsp.buf.code_action()<CR>", { noremap = true })
 vim.api.nvim_set_keymap("n", "<leader>cl", "<cmd>lua vim.lsp.codelens.run()<CR>", { noremap = true })
 vim.api.nvim_set_keymap("n", "<leader>aa", "<cmd>lua vim.diagnostic.setqflist()<CR>", { noremap = true }) -- all workspace diagnostics
-vim.api.nvim_set_keymap("n", "<leader>ae", "<cmd>lua vim.diagnostic.setqflist({severity = \"E\"})<CR>", { noremap = true }) -- all workspace errors
-vim.api.nvim_set_keymap("n", "<leader>aw", "<cmd>lua vim.diagnostic.setqflist({severity = \"W\"})<CR>", { noremap = true }) -- all workspace warnings
+vim.api.nvim_set_keymap("n", "<leader>ae", "<cmd>lua vim.diagnostic.setqflist({severity = \"E\"})<CR>",
+        { noremap = true })                                                                               -- all workspace errors
+vim.api.nvim_set_keymap("n", "<leader>aw", "<cmd>lua vim.diagnostic.setqflist({severity = \"W\"})<CR>",
+        { noremap = true })                                                                               -- all workspace warnings
 vim.api.nvim_set_keymap("n", "<leader>d", "<cmd>lua vim.diagnostic.setloclist()<CR>", { noremap = true }) -- buffer diagnostics only

--- a/dotfiles/neovim/lua/custom-orgmode.lua
+++ b/dotfiles/neovim/lua/custom-orgmode.lua
@@ -1,10 +1,10 @@
 require("orgmode").setup({
-  org_agenda_files = {"~/.org/agenda/*"},
-  org_default_notes_file = "~/.org/refile.org",
+        org_agenda_files = { "~/.org/agenda/*" },
+        org_default_notes_file = "~/.org/refile.org",
 
-  win_split_mode = "vertical",
+        win_split_mode = "vertical",
 
-  org_todo_keywords = {'TODO', 'BLOCKED', '|', 'DONE', 'DELEGATED'}
+        org_todo_keywords = { 'TODO', 'BLOCKED', '|', 'DONE', 'DELEGATED' }
 })
 
 -- it's not clear to me whether this is actually doing anything.

--- a/dotfiles/neovim/lua/custom-rest-nvim.lua
+++ b/dotfiles/neovim/lua/custom-rest-nvim.lua
@@ -1,44 +1,44 @@
 require("rest-nvim").setup({
-  -- Open request results in a horizontal split
-  result_split_horizontal = false,
-  -- Keep the http file buffer above|left when split horizontal|vertical
-  result_split_in_place = false,
-  -- Skip SSL verification, useful for unknown certificates
-  skip_ssl_verification = false,
-  -- Encode URL before making request
-  encode_url = true,
-  -- Highlight request on run
-  highlight = {
-    enabled = true,
-    timeout = 150,
-  },
-  result = {
-    -- toggle showing URL, HTTP info, headers at top the of result window
-    show_url = true,
-    -- show the generated curl command in case you want to launch
-    -- the same request via the terminal (can be verbose)
-    show_curl_command = false,
-    show_http_info = true,
-    show_headers = true,
-    -- executables or functions for formatting response body [optional]
-    -- set them to false if you want to disable them
-    formatters = {
-      json = "jq",
-      html = function(body)
-        return vim.fn.system({"tidy", "-i", "-q", "-"}, body)
-      end
-    },
-  },
-  -- Jump to request line on run
-  jump_to_request = false,
-  env_file = '.env',
-  custom_dynamic_variables = {},
-  yank_dry_run = true,
+        -- Open request results in a horizontal split
+        result_split_horizontal = false,
+        -- Keep the http file buffer above|left when split horizontal|vertical
+        result_split_in_place = false,
+        -- Skip SSL verification, useful for unknown certificates
+        skip_ssl_verification = false,
+        -- Encode URL before making request
+        encode_url = true,
+        -- Highlight request on run
+        highlight = {
+                enabled = true,
+                timeout = 150,
+        },
+        result = {
+                -- toggle showing URL, HTTP info, headers at top the of result window
+                show_url = true,
+                -- show the generated curl command in case you want to launch
+                -- the same request via the terminal (can be verbose)
+                show_curl_command = false,
+                show_http_info = true,
+                show_headers = true,
+                -- executables or functions for formatting response body [optional]
+                -- set them to false if you want to disable them
+                formatters = {
+                        json = "jq",
+                        html = function(body)
+                                return vim.fn.system({ "tidy", "-i", "-q", "-" }, body)
+                        end
+                },
+        },
+        -- Jump to request line on run
+        jump_to_request = false,
+        env_file = '.env',
+        custom_dynamic_variables = {},
+        yank_dry_run = true,
 })
 
 -- set files with .http extension to "http" filetype
 vim.filetype.add({
-  extension = {
-    http = "http"
-  }
+        extension = {
+                http = "http"
+        }
 })

--- a/dotfiles/neovim/lua/custom-which-key.lua
+++ b/dotfiles/neovim/lua/custom-which-key.lua
@@ -1,4 +1,4 @@
-require("which-key").setup { }
+require("which-key").setup {}
 
 -- add a binding to open the interactive which-key popup
 vim.api.nvim_set_keymap("n", "<leader>k", "<cmd>WhichKey<CR>", { noremap = true })

--- a/dotfiles/neovim/lua/tree-config.lua
+++ b/dotfiles/neovim/lua/tree-config.lua
@@ -1,14 +1,14 @@
 -- customize nvim-tree rendering
 require("nvim-tree").setup({
-  renderer = {
-    group_empty = true,
-    highlight_git = true
-  },
-  view = {
-    adaptive_size = true
-  },
-  diagnostics = { enable = true },
-  filters = { dotfiles = false }
+        renderer = {
+                group_empty = true,
+                highlight_git = true
+        },
+        view = {
+                adaptive_size = true
+        },
+        diagnostics = { enable = true },
+        filters = { dotfiles = false }
 })
 
 -- tree view mappings
@@ -18,7 +18,6 @@ vim.api.nvim_set_keymap("n", "<space>tt", "<cmd>:NvimTreeToggle<CR>", { noremap 
 vim.api.nvim_set_keymap("n", "<space>tf", "<cmd>:NvimTreeFindFile<CR>", { noremap = true })
 
 require("nvim-web-devicons").setup {
-  color_icons = true;
-  default = true;
+        color_icons = true,
+        default = true,
 }
-

--- a/dotfiles/neovim/lua/treesitter.lua
+++ b/dotfiles/neovim/lua/treesitter.lua
@@ -1,20 +1,19 @@
 require("nvim-treesitter.configs").setup {
-  -- A list of parser names, or "all"
-  ensure_installed = {},
+        -- A list of parser names, or "all"
+        ensure_installed = {},
 
-  auto_install = false,
+        auto_install = false,
 
-  -- List of parsers to ignore installing (for "all")
-  ignore_install = {},
+        -- List of parsers to ignore installing (for "all")
+        ignore_install = {},
 
-  highlight = {
-    enable = true,
+        highlight = {
+                enable = true,
 
-    -- NOTE: these are the names of the parsers and not the filetype. (for example if you want to
-    -- disable highlighting for the `tex` filetype, you need to include `latex` in this list as this is
-    -- the name of the parser)
-    -- list of language that will be disabled
-    disable = {},
-  },
+                -- NOTE: these are the names of the parsers and not the filetype. (for example if you want to
+                -- disable highlighting for the `tex` filetype, you need to include `latex` in this list as this is
+                -- the name of the parser)
+                -- list of language that will be disabled
+                disable = {},
+        },
 }
-

--- a/dotfiles/neovim/lua/vim-stuff.lua
+++ b/dotfiles/neovim/lua/vim-stuff.lua
@@ -10,4 +10,3 @@ vim.opt.expandtab = true
 -- make colors look nice
 vim.opt.background = "light"
 vim.cmd("colorscheme solarized")
-

--- a/home.nix
+++ b/home.nix
@@ -108,6 +108,7 @@ in
         dhall-lsp-server
         fzf
         kotlin-language-server
+        lua-language-server
         nil
         nodePackages.typescript-language-server
         pyright


### PR DESCRIPTION
This PR fixes nix LSP config to specify a formatting command. Previously, `<leader>cf` wasn't doing anything, and I learned eventually that that's because there wasn't a formatting command specified. I specify `nixpkgs-fmt` here, since I have it installed as part of my home.

I also didn't have a lua lsp set up at all. This adds one with special configuration (noted in comments in the file that sets it up) for use with nvim config files.

TODO:

* [x] go through and run the lua lsp formatter on all the lua config files