### PR TITLE
Support string and file search in vimwiki from anywhere

### DIFF
--- a/dotfiles/neovim/lua/fzf-config.lua
+++ b/dotfiles/neovim/lua/fzf-config.lua
@@ -13,7 +13,8 @@ vim.api.nvim_set_keymap("n", "<space>fg", "<cmd>:FzfLua git_files<CR>", { norema
 vim.api.nvim_set_keymap("n", "<space>flds", "<cmd>:FzfLua lsp_document_symbols<CR>", { noremap = true })
 vim.api.nvim_set_keymap("n", "<space>flws", "<cmd>:FzfLua lsp_workspace_symbols<CR>", { noremap = true })
 vim.api.nvim_set_keymap("n", "<space>fs", "<cmd>:FzfLua grep_project<CR>", { noremap = true })
-vim.api.nvim_set_keymap("n", "<space>fw", ":lua require('fzf-lua').live_grep({cwd='~/vimwiki'})<CR>", { noremap = true })
+vim.api.nvim_set_keymap("n", "<space>fws", ":lua require('fzf-lua').live_grep({cwd='~/vimwiki'})<CR>", { noremap = true })
+vim.api.nvim_set_keymap("n", "<space>fwf", ":lua require('fzf-lua').files({cwd='~/vimwiki'})<CR>", { noremap = true })
 
 -- make fzf the default select ui
 require("fzf-lua").register_ui_select()


### PR DESCRIPTION
The same way that `ff` and `fs` are "search files" and "search strings," `fwf` and `fws` are now "search vimwiki files" and "search vimwiki strings".

Maybe I can start using vimwiki from everywhere instead of having an always open vimwiki tmux tab after this 🤔 