### PR TITLE
Add and configure nvim-test to run tests from nvim

### DIFF
--- a/attrs/vimPlugins.nix
+++ b/attrs/vimPlugins.nix
@@ -9,6 +9,15 @@ let
       hash = "sha256-uOiKzhl+3Pi0pFLecQqUWveN+1Z3Tu/UiSPBmS+bio8=";
     };
   };
+  nvim-test = pkgs.vimUtils.buildVimPluginFrom2Nix {
+    name = "nvim-test";
+    src = pkgs.fetchFromGitHub {
+      owner = "klen";
+      repo = "nvim-test";
+      rev = "1.4.1";
+      hash = "sha256-mMi07UbMWmC75DFfW1b+sR2uRPxizibFwS2qcN9rpLI=";
+    };
+  };
 in
 with vimPlugins;
 [
@@ -28,6 +37,7 @@ with vimPlugins;
   nvim-jqx
   nvim-lspconfig
   nvim-metals
+  nvim-test
   nvim-tree-lua
   nvim-web-devicons
   orgmode

--- a/attrs/vimPlugins.nix
+++ b/attrs/vimPlugins.nix
@@ -34,6 +34,10 @@ with vimPlugins;
   luasnip
   neogit
   nvim-cmp
+  nvim-dap
+  nvim-dap-ui
+  nvim-dap-virtual-text
+  nvim-dap-python
   nvim-jqx
   nvim-lspconfig
   nvim-metals

--- a/dotfiles/neovim/ftplugin/python.lua
+++ b/dotfiles/neovim/ftplugin/python.lua
@@ -1,2 +1,28 @@
 -- add special way to run black, since pyright doesn't have a code format option
 vim.api.nvim_set_keymap("n", "<leader>f", "<cmd>!black %<CR>", { noremap = true })
+vim.api.nvim_set_keymap("n", "<leader>cta", ":TestSuite<CR>", { noremap = true, desc = "Run all detected tests" })
+vim.api.nvim_set_keymap("n", "<leader>ctf", ":TestFile<CR>", { noremap = true, desc = "Run tests in this file" })
+vim.api.nvim_set_keymap("n", "<leader>ctl", ":TestLast<CR>", { noremap = true, desc = "Rerun the last run test" })
+vim.api.nvim_set_keymap("n", "<leader>ctt", ":TestNearest<CR>", { noremap = true, desc = "Run nearest test to cursor" })
+
+-- configure nvim-test
+-- python only for now, which is why it's in ftplugin instead of somewhere more general
+-- I'll move it if I end up using it often and borrowing it for other languages
+require('nvim-test').setup {
+        run = true,                     -- run tests (using for debug)
+        commands_create = true,         -- create commands (TestFile, TestLast, ...)
+        filename_modifier = ":.",       -- modify filenames before tests run(:h filename-modifiers)
+        silent = false,                 -- less notifications
+        term = "terminal",              -- a terminal to run ("terminal"|"toggleterm")
+        termOpts = {
+                direction = "vertical", -- terminal's direction ("horizontal"|"vertical"|"float")
+                width = 96,             -- terminal's width (for vertical|float)
+                height = 24,            -- terminal's height (for horizontal|float)
+                go_back = false,        -- return focus to original window after executing
+                stopinsert = "auto",    -- exit from insert mode (true|false|"auto")
+                keep_one = true,        -- keep only one terminal for testing
+        },
+        runners = {
+                python = "nvim-test.runners.pytest",
+        }
+}

--- a/dotfiles/neovim/ftplugin/python.lua
+++ b/dotfiles/neovim/ftplugin/python.lua
@@ -1,28 +1,21 @@
 -- add special way to run black, since pyright doesn't have a code format option
 vim.api.nvim_set_keymap("n", "<leader>f", "<cmd>!black %<CR>", { noremap = true })
-vim.api.nvim_set_keymap("n", "<leader>cta", ":TestSuite<CR>", { noremap = true, desc = "Run all detected tests" })
-vim.api.nvim_set_keymap("n", "<leader>ctf", ":TestFile<CR>", { noremap = true, desc = "Run tests in this file" })
-vim.api.nvim_set_keymap("n", "<leader>ctl", ":TestLast<CR>", { noremap = true, desc = "Rerun the last run test" })
-vim.api.nvim_set_keymap("n", "<leader>ctt", ":TestNearest<CR>", { noremap = true, desc = "Run nearest test to cursor" })
 
--- configure nvim-test
--- python only for now, which is why it's in ftplugin instead of somewhere more general
--- I'll move it if I end up using it often and borrowing it for other languages
-require('nvim-test').setup {
-        run = true,                     -- run tests (using for debug)
-        commands_create = true,         -- create commands (TestFile, TestLast, ...)
-        filename_modifier = ":.",       -- modify filenames before tests run(:h filename-modifiers)
-        silent = false,                 -- less notifications
-        term = "terminal",              -- a terminal to run ("terminal"|"toggleterm")
-        termOpts = {
-                direction = "vertical", -- terminal's direction ("horizontal"|"vertical"|"float")
-                width = 96,             -- terminal's width (for vertical|float)
-                height = 24,            -- terminal's height (for horizontal|float)
-                go_back = false,        -- return focus to original window after executing
-                stopinsert = "auto",    -- exit from insert mode (true|false|"auto")
-                keep_one = true,        -- keep only one terminal for testing
-        },
-        runners = {
-                python = "nvim-test.runners.pytest",
-        }
-}
+require("dap-python").setup("python")
+
+vim.api.nvim_set_keymap("n",
+        "<leader>cdb",
+        "<cmd>lua require('dap').toggle_breakpoint()<CR>",
+        { noremap = true })
+vim.api.nvim_set_keymap("n",
+        "<leader>cdc",
+        "<cmd>lua require('dap').continue()<CR>",
+        { noremap = true })
+vim.api.nvim_set_keymap("n",
+        "<leader>cdr",
+        "<cmd>lua require('dap').repl.open()<CR>",
+        { noremap = true })
+vim.api.nvim_set_keymap("n",
+        "<leader>cdt",
+        "<cmd>lua require('dap-python').test_method()<CR>",
+        { noremap = true })

--- a/dotfiles/neovim/init.lua
+++ b/dotfiles/neovim/init.lua
@@ -7,6 +7,7 @@
 -- so they all hang out together in lsp-config.lua
 
 require("completion-config")
+require("custom-dap-config")
 require("custom-jq-config")
 require("custom-lsp-config")
 require("custom-orgmode")

--- a/dotfiles/neovim/lua/custom-dap-config.lua
+++ b/dotfiles/neovim/lua/custom-dap-config.lua
@@ -1,0 +1,9 @@
+
+require("nvim-dap-virtual-text").setup()
+
+require("dapui").setup()
+
+vim.api.nvim_set_keymap("n",
+        "<leader>cdut",
+        "<cmd>lua require('dapui').toggle()<CR>",
+        { noremap = true })

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1694465129,
-        "narHash": "sha256-8BQiuobMrCfCbGM7w6Snx+OBYdtTIm0+cGVaKwQ5BFg=",
+        "lastModified": 1695108154,
+        "narHash": "sha256-gSg7UTVtls2yO9lKtP0yb66XBHT1Fx5qZSZbGMpSn2c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9787dffff5d315c9593d3f9fb0f9bf2097e1b57b",
+        "rev": "07682fff75d41f18327a871088d20af2710d4744",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1694937365,
-        "narHash": "sha256-iHZSGrb9gVpZRR4B2ishUN/1LRKWtSHZNO37C8z1SmA=",
+        "lastModified": 1697851979,
+        "narHash": "sha256-lJ8k4qkkwdvi+t/Xc6Fn74kUuobpu9ynPGxNZR6OwoA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5d017a8822e0907fb96f7700a319f9fe2434de02",
+        "rev": "5550a85a087c04ddcace7f892b0bdc9d8bb080c8",
         "type": "github"
       },
       "original": {

--- a/home.nix
+++ b/home.nix
@@ -51,7 +51,6 @@ let
   ];
 
   patchedFonts = [
-    # need the parens because otherwise the space makes it look like list entries
     (pkgs.nerdfonts.override { fonts = [ "Hasklig" "SourceCodePro" ]; })
   ];
 


### PR DESCRIPTION
Bindings:

* `<leader>cdb` -- toggle breakpoint at line
* `<leader>cdc` -- debug continue
* `<leader>cdr` -- launch debug repl that I don't currently understand how to use
* `<leader>cdt` -- run test under cursor (assuming you have correct test runner configured)
* `<leader>cdut` -- toggle debug UI

This also sets up virtual text, which highlights variable values that are changing while in a debug session

Setting the test runner depends on running `lua require('dap-python').test_runner = 'pytest'`, or setting it globally -- I'm not sure I'll _always_ use pytest, but it might be worth setting in the future. Oh well.