### PR TITLE
Add direnv lib/ directory with poetry layout

### DIFF
--- a/dotfiles/direnv/lib/layout_poetry.sh
+++ b/dotfiles/direnv/lib/layout_poetry.sh
@@ -1,0 +1,19 @@
+# poetry layout for direnv
+# see https://github.com/direnv/direnv/issues/592#issuecomment-856227234
+layout_poetry() {
+  if [[ ! -f pyproject.toml ]]; then
+    log_error 'No pyproject.toml found. Use `poetry new` or `poetry init` to create one first.'
+    exit 2
+  fi
+
+  local VENV=$(poetry env info --path)
+  if [[ -z $VENV || ! -d $VENV/bin ]]; then
+    log_error 'No poetry virtual environment found. Use `poetry install` to create one first.'
+    exit 2
+  fi
+
+  export VIRTUAL_ENV=$VENV
+  export POETRY_ACTIVE=1
+  PATH_add "$VENV/bin"
+}
+

--- a/home.nix
+++ b/home.nix
@@ -90,6 +90,11 @@ in
 
   xdg.configFile."lazygit/config.yml".text = builtins.readFile ./dotfiles/lazygit.yml;
 
+  xdg.configFile."direnv/lib" = {
+    source = ./dotfiles/direnv/lib;
+    recursive = true;
+  };
+
   programs = {
 
     # Let Home Manager install and manage itself.


### PR DESCRIPTION
Direnv will source anything in that directory with a `.sh` extension, so I can use it to add special functions that'll be available anywhere I use direnv. Neat!