### PR TITLE
Set up dap-python to run tests without coverage

### DIFF
--- a/dotfiles/neovim/ftplugin/python.lua
+++ b/dotfiles/neovim/ftplugin/python.lua
@@ -1,9 +1,15 @@
 -- add special way to run black, since pyright doesn't have a code format option
 vim.api.nvim_set_keymap("n", "<leader>f", "<cmd>!black %<CR>", { noremap = true, desc = "Run black on buffer" })
 
-require("dap-python").setup("python")
+local dap_python = require("dap-python")
 
-require("dap-python").test_runner = "pytest"
+dap_python.setup("python")
+dap_python.test_runner = "pytest_no_cov"
+function dap_python.test_runners.pytest_no_cov(classname, methodname)
+        local test_module, test_args = dap_python.test_runners.pytest(classname, methodname)
+        test_args[#test_args + 1] = "--no-cov"
+        return test_module, test_args
+end
 
 vim.api.nvim_set_keymap("n",
         "<leader>cdb",


### PR DESCRIPTION
`--cov` messes with debuggers, and lots of repos at $work have it set up. Instead of having to remember to turn it off before debugging, make the default not including `--cov`.