### PR TITLE
Add location list binding and lines / grep_last bindings

### DIFF
--- a/dotfiles/neovim/lua/fzf-config.lua
+++ b/dotfiles/neovim/lua/fzf-config.lua
@@ -1,3 +1,5 @@
+local fzfLua = require("fzf-lua")
+
 -- make find much better
 vim.opt.path:remove "/usr/include"
 vim.opt.path:append "**"
@@ -8,18 +10,25 @@ vim.opt.wildignore:append "**/target/*"
 vim.opt.wildignore:append "**/.bsp/*"
 vim.opt.wildignore:append "**/.metals/*"
 vim.api.nvim_set_keymap("n", "<space>fb", "<cmd>:FzfLua buffers<CR>", { noremap = true, desc = "Choose open buffer" })
+vim.api.nvim_set_keymap("n", "<space>fl", "<cmd>:FzfLua lines<CR>", { noremap = true, desc = "Choose file in workspace" })
 vim.api.nvim_set_keymap("n", "<space>ff", "<cmd>:FzfLua files<CR>", { noremap = true, desc = "Choose file in workspace" })
 vim.api.nvim_set_keymap("n", "<space>fg", "<cmd>:FzfLua git_files<CR>", { noremap = true, desc = "Choose git file" })
-vim.api.nvim_set_keymap("n", "<space>flds", "<cmd>:FzfLua lsp_document_symbols<CR>",
-        { noremap = true, desc = "Search document symbols" })
-vim.api.nvim_set_keymap("n", "<space>flws", "<cmd>:FzfLua lsp_workspace_symbols<CR>",
-        { noremap = true, desc = "Search workspace symbols" })
 vim.api.nvim_set_keymap("n", "<space>fs", "<cmd>:FzfLua grep_project<CR>",
         { noremap = true, desc = "Search string in project" })
+vim.api.nvim_set_keymap("n", "<space>fls", "<cmd>:FzfLua grep_last<CR>",
+        { noremap = true, desc = "Repeat last search" })
 vim.api.nvim_set_keymap("n", "<space>fws", ":lua require('fzf-lua').live_grep({cwd='~/vimwiki'})<CR>",
         { noremap = true, desc = "Search in vimwiki" })
 vim.api.nvim_set_keymap("n", "<space>fwf", ":lua require('fzf-lua').files({cwd='~/vimwiki'})<CR>",
         { noremap = true, desc = "Search files in vimwiki" })
 
 -- make fzf the default select ui
-require("fzf-lua").register_ui_select()
+fzfLua.register_ui_select()
+
+fzfLua.setup({
+        keymap = {
+                fzf = {
+                        ["ctrl-a"] = "select-all+accept"
+                }
+        }
+})

--- a/dotfiles/neovim/lua/fzf-config.lua
+++ b/dotfiles/neovim/lua/fzf-config.lua
@@ -10,7 +10,7 @@ vim.opt.wildignore:append "**/target/*"
 vim.opt.wildignore:append "**/.bsp/*"
 vim.opt.wildignore:append "**/.metals/*"
 vim.api.nvim_set_keymap("n", "<space>fb", "<cmd>:FzfLua buffers<CR>", { noremap = true, desc = "Choose open buffer" })
-vim.api.nvim_set_keymap("n", "<space>fl", "<cmd>:FzfLua lines<CR>", { noremap = true, desc = "Choose file in workspace" })
+vim.api.nvim_set_keymap("n", "<space>fL", "<cmd>:FzfLua lines<CR>", { noremap = true, desc = "Choose file in workspace" })
 vim.api.nvim_set_keymap("n", "<space>ff", "<cmd>:FzfLua files<CR>", { noremap = true, desc = "Choose file in workspace" })
 vim.api.nvim_set_keymap("n", "<space>fg", "<cmd>:FzfLua git_files<CR>", { noremap = true, desc = "Choose git file" })
 vim.api.nvim_set_keymap("n", "<space>fs", "<cmd>:FzfLua grep_project<CR>",


### PR DESCRIPTION
* In a search floating window, `ctrl+a` to pop the results into a location list instead
* `<space>fls` for repeating the last search
* `<space>fL` for searching lines in a buffer

These changes make it nicer to search within a file using fzf's nice popup instead of the built-in `/` + `n` navigation, make it easy to run the previous search after selecting one of the results, and make it easy to put the results somewhere for convenient access after I've found what I'm looking for