### PR TITLE
Add libsixel

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -10,6 +10,9 @@ let
     # traverse json with the jq command
     # https://stedolan.github.io/jq/
     pkgs.jq
+    # make it so terminals can print images nicely, maybe
+    # https://saitoha.github.io/libsixel/
+    pkgs.libsixel
     # faster grep with rg
     # https://github.com/BurntSushi/ripgrep
     pkgs.ripgrep


### PR DESCRIPTION
This PR adds `libsixel` -- it doesn't fully resolve #101, since `zellij` + sixel on WSL doesn't quite work, but it at least means that the whole terminal image rendering question can be consistent -- just use `sixel` via the default `eval` command from that `patat` discussion. I'll still have to do the multiplexer session + normal session song and dance, but hey, progress.

![image](https://github.com/user-attachments/assets/317c06e5-221f-4f5b-88af-9ce0aec8be66)
