### PR TITLE
Add ReadingTime function

### DIFF
--- a/dotfiles/neovim/ftplugin/markdown.lua
+++ b/dotfiles/neovim/ftplugin/markdown.lua
@@ -311,3 +311,11 @@ require('render-markdown').setup({
 
 vim.opt_local.foldmethod = "expr"
 vim.opt_local.foldexpr = "nvim_treesitter#foldexpr()"
+
+local function readingTime()
+        local count = vim.fn.wordcount().words
+        local readingTimeMinutes = count / 238
+        print(string.format("%.1f", readingTimeMinutes) .. " minutes")
+end
+
+vim.api.nvim_create_user_command("ReadingTime", readingTime, {})


### PR DESCRIPTION
Command gets created in the ftplugin for markdown, which... might be wrong? I think that might mean it's available in any buffers when I have a markdown buffer open. That's fine though, I only really care that it's available when I'm in markdown buffers, so, you know, requirements met.

Closes #99 