### PR TITLE
Vendor git and bash

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,12 @@
         inherit nixpkgs home-manager system;
       };
     in
-    flake-utils.lib.eachDefaultSystem (system: {
-      homeConfigurations = mkHome { inherit system; };
-    });
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = [ pkgs.bash ];
+        };
+        homeConfigurations = mkHome { inherit system; };
+      });
 }

--- a/home.nix
+++ b/home.nix
@@ -101,6 +101,10 @@ in
     # Let Home Manager install and manage itself.
     home-manager.enable = true;
 
+    git = {
+      enable = true;
+    };
+
     lazygit = {
       enable = true;
       settings = {

--- a/scripts/switch
+++ b/scripts/switch
@@ -22,7 +22,7 @@ function build_macos_x86() {
 }
 
 function activate_home() {
-  nix run nixpkgs#bash -- ./result/activate
+  nix develop --command ./result/activate
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then


### PR DESCRIPTION
Vendoring bash makes flake evaluations on MacOS faster. Vendoring git protects me from xtools upgrades borking git